### PR TITLE
fix: This fixes all issues with udp and p2p.

### DIFF
--- a/Assets/Mirage/Runtime/Transport/FizzySteamyMirror/Message.cs
+++ b/Assets/Mirage/Runtime/Transport/FizzySteamyMirror/Message.cs
@@ -1,3 +1,5 @@
+#if !DISABLESTEAMWORKS
+
 using Mirage.SocketLayer;
 
 namespace Mirage.Sockets.FizzySteam
@@ -14,3 +16,4 @@ namespace Mirage.Sockets.FizzySteam
         }
     }
 }
+#endif

--- a/Assets/Mirage/Runtime/Transport/FizzySteamyMirror/SteamOptions.cs
+++ b/Assets/Mirage/Runtime/Transport/FizzySteamyMirror/SteamOptions.cs
@@ -1,3 +1,4 @@
+#if !DISABLESTEAMWORKS
 #region Statements
 
 using System;
@@ -26,3 +27,4 @@ namespace Mirage.Sockets.FizzySteam
         SDR = 2
     }
 }
+#endif

--- a/Assets/Mirage/Runtime/Transport/FizzySteamyMirror/SteamOptions.cs
+++ b/Assets/Mirage/Runtime/Transport/FizzySteamyMirror/SteamOptions.cs
@@ -15,6 +15,8 @@ namespace Mirage.Sockets.FizzySteam
         [Tooltip("Enter address of the ip of server connect to or the steam user id to if in p2p mode.")] public string Address = "localhost";
         [Tooltip("Only used in udp mode.")] public ushort Port = 7777;
         [Range(1,512), Tooltip("Number of messages we want to poll steam for at once time.")] public int MaxMessagesPolling = 256;
+        [Tooltip("Set this to false if you want to initialize the SteamClient yourself.")]
+        public bool InitSteam = true;
     }
 
     public enum SteamModes : byte

--- a/Assets/Mirage/Runtime/Transport/FizzySteamyMirror/SteamOptions.cs
+++ b/Assets/Mirage/Runtime/Transport/FizzySteamyMirror/SteamOptions.cs
@@ -11,20 +11,42 @@ namespace Mirage.Sockets.FizzySteam
     [Serializable]
     public class SteamOptions
     {
-        [Tooltip("Enable Debug Mode")] public bool EnableDebug = false;
-        [Tooltip("Which type of steam mode do you want to use.")] public SteamModes SteamMode = SteamModes.UDP;
-        [Tooltip("Enter address of the ip of server connect to or the steam user id to if in p2p mode.")] public string Address = "localhost";
-        [Tooltip("Only used in udp mode.")] public ushort Port = 7777;
-        [Range(1,512), Tooltip("Number of messages we want to poll steam for at once time.")] public int MaxMessagesPolling = 256;
+        [Header("Steam Initialization Options")]
+
+        [Tooltip("Please assign this to your app id once you have none. Default is demo space wars by steam.")]
+        public uint AppID = 480;
+
+        [Tooltip("Which type of steam mode do you want to use.")]
+        public SteamModes SteamMode = SteamModes.UDP;
+
+        [Tooltip("Use steam relay system?")]
+        public bool useSteamRelay = true;
+
         [Tooltip("Set this to false if you want to initialize the SteamClient yourself.")]
         public bool InitSteam = true;
+
+        [Header("Debug Options")]
+
+        [Tooltip("Enable Debug Mode")]
+        public bool EnableDebug = false;
+
+        [Header("Network Settings")]
+
+        [Range(1, 512), Tooltip("Number of messages we want to poll steam for at once time.")]
+        public int MaxMessagesPolling = 256;
+
+        [Tooltip("Enter address of the ip of server connect to or the steam user id to if in p2p mode.")]
+        public string Address = "localhost";
+
+        [Tooltip("Only used in udp mode.")]
+        public ushort Port = 7777;
     }
 
     public enum SteamModes : byte
     {
         P2P = 0,
         UDP = 1,
-        SDR = 2
+        //SDR = 2
     }
 }
 #endif

--- a/Assets/Mirage/Runtime/Transport/FizzySteamyMirror/SteamSocketFactory.cs
+++ b/Assets/Mirage/Runtime/Transport/FizzySteamyMirror/SteamSocketFactory.cs
@@ -5,6 +5,7 @@ using System;
 using System.Net;
 using System.Net.Sockets;
 using Mirage.SocketLayer;
+using Steamworks;
 using UnityEngine;
 using UnityEngine.Serialization;
 
@@ -96,6 +97,9 @@ namespace Mirage.Sockets.FizzySteam
         /// <summary>Creates the <see cref="EndPoint" /> that the Client Socket will connect to using the parameter given</summary>
         public override IEndPoint GetConnectEndPoint(string address = null, ushort? port = null)
         {
+            if (SteamOptions.SteamMode == SteamModes.P2P)
+                return new SteamEndpoint(new CSteamID(ulong.Parse(address ?? SteamOptions.Address)));
+
             string addressString = address ?? SteamOptions.Address;
             IPAddress ipAddress = GetAddress(addressString);
 

--- a/Assets/Mirage/Runtime/Transport/FizzySteamyMirror/SteamSocketFactory.cs
+++ b/Assets/Mirage/Runtime/Transport/FizzySteamyMirror/SteamSocketFactory.cs
@@ -1,3 +1,4 @@
+#if !DISABLESTEAMWORKS
 #region Statements
 
 using System;
@@ -142,3 +143,4 @@ namespace Mirage.Sockets.FizzySteam
         #endregion
     }
 }
+#endif

--- a/Assets/Mirage/Runtime/Transport/FizzySteamyMirror/SteamSocketManager.cs
+++ b/Assets/Mirage/Runtime/Transport/FizzySteamyMirror/SteamSocketManager.cs
@@ -291,8 +291,8 @@ namespace Mirage.Sockets.FizzySteam
             _onConnectionChange = null;
             SteamNetworkingSockets.DestroyPollGroup(_pollGroup);
             _steamInitialized = false;
-            
-            if(options.InitSteam)
+
+            if (_steamOptions.InitSteam)
                 SteamAPI.Shutdown();
         }
 

--- a/Assets/Mirage/Runtime/Transport/FizzySteamyMirror/SteamSocketManager.cs
+++ b/Assets/Mirage/Runtime/Transport/FizzySteamyMirror/SteamSocketManager.cs
@@ -350,7 +350,7 @@ namespace Mirage.Sockets.FizzySteam
                         SteamNetworkingSockets.CreateListenSocketP2P(0, 0, Array.Empty<SteamNetworkingConfigValue_t>());
                     break;
                 case SteamModes.SDR:
-                    break;
+                    throw new NotImplementedException("Still not implemented yet.");
                 case SteamModes.UDP:
 
                     _endPoint = (SteamSocketFactory.SteamEndPointWrapper)endPoint;
@@ -386,7 +386,7 @@ namespace Mirage.Sockets.FizzySteam
                     SteamNetworkingSockets.ConnectP2P(ref steamIdentity, 0, 0, Array.Empty<SteamNetworkingConfigValue_t>());
                     break;
                 case SteamModes.SDR:
-                    break;
+                    throw new NotImplementedException("Still not implemented yet.");
                 case SteamModes.UDP:
 
                     _endPoint = (SteamSocketFactory.SteamEndPointWrapper)endPoint;

--- a/Assets/Mirage/Runtime/Transport/FizzySteamyMirror/SteamSocketManager.cs
+++ b/Assets/Mirage/Runtime/Transport/FizzySteamyMirror/SteamSocketManager.cs
@@ -114,9 +114,8 @@ namespace Mirage.Sockets.FizzySteam
 
         public bool Update()
         {
-            if (!_steamInitialized) return false;
-
-            SteamAPI.RunCallbacks();
+            if (_steamInitialized)
+                SteamAPI.RunCallbacks();
 
             var receivedMessages = new IntPtr[_steamOptions.MaxMessagesPolling];
             int receivedCount;
@@ -143,7 +142,6 @@ namespace Mirage.Sockets.FizzySteam
                             $"Steam back-end queuing up messages to buffer. Current Message queue: {BufferQueue.Count}");
 
                     SteamNetworkingMessage_t.Release(receivedMessages[i]);
-                    //Marshal.DestroyStructure<SteamNetworkingMessage_t>(receivedMessages[i]);
                 }
             }
 

--- a/Assets/Mirage/Runtime/Transport/FizzySteamyMirror/SteamSocketManager.cs
+++ b/Assets/Mirage/Runtime/Transport/FizzySteamyMirror/SteamSocketManager.cs
@@ -19,7 +19,7 @@ namespace Mirage.Sockets.FizzySteam
 
     public class SteamEndpoint : IEndPoint, IEquatable<SteamEndpoint>
     {
-        public CSteamID Address;
+        public readonly CSteamID Address;
 
         public SteamEndpoint(CSteamID address)
         {

--- a/Assets/Mirage/Runtime/Transport/FizzySteamyMirror/SteamSocketManager.cs
+++ b/Assets/Mirage/Runtime/Transport/FizzySteamyMirror/SteamSocketManager.cs
@@ -392,7 +392,7 @@ namespace Mirage.Sockets.FizzySteam
 
                     _steamSocketManager.HoHSteamNetConnection = SteamNetworkingSockets.ConnectP2P(ref steamIdentity, 0, 0, Array.Empty<SteamNetworkingConfigValue_t>());
 
-                    _steamSocketManager.SteamConnections.TryAdd(steamEndPoint, _steamSocketManager.HoHSteamNetConnection);
+                    _steamSocketManager.SteamConnections.Add(steamEndPoint, _steamSocketManager.HoHSteamNetConnection);
                     break;
                 case SteamModes.UDP:
 

--- a/Assets/Mirage/Runtime/Transport/FizzySteamyMirror/SteamSocketManager.cs
+++ b/Assets/Mirage/Runtime/Transport/FizzySteamyMirror/SteamSocketManager.cs
@@ -1,3 +1,5 @@
+#if !DISABLESTEAMWORKS
+
 #region Statements
 
 using System;
@@ -15,7 +17,7 @@ using Debug = UnityEngine.Debug;
 
 namespace Mirage.Sockets.FizzySteam
 {
-    #region Endpoint Wrappers
+#region Endpoint Wrappers
 
     public class SteamEndpoint : IEndPoint, IEquatable<SteamEndpoint>
     {
@@ -66,11 +68,11 @@ namespace Mirage.Sockets.FizzySteam
         }
     }
 
-    #endregion
+#endregion
 
     internal sealed class SteamSocketManager : IDisposable
     {
-        #region Fields
+#region Fields
 
         public HSteamListenSocket Socket;
         public HSteamNetConnection HoHSteamNetConnection;
@@ -82,9 +84,9 @@ namespace Mirage.Sockets.FizzySteam
         private readonly SteamOptions _steamOptions;
         private bool _steamInitialized;
 
-        #endregion
+#endregion
 
-        #region Class Methods
+#region Class Methods
 
         /// <summary>
         /// 
@@ -276,9 +278,9 @@ namespace Mirage.Sockets.FizzySteam
             }
         }
 
-        #endregion
+#endregion
 
-        #region Implementation of IDisposable
+#region Implementation of IDisposable
 
         /// <summary>Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.</summary>
         public void Dispose()
@@ -292,21 +294,21 @@ namespace Mirage.Sockets.FizzySteam
             SteamAPI.Shutdown();
         }
 
-        #endregion
+#endregion
     }
 
     internal sealed class SteamSocket : ISocket
     {
-        #region Fields
+#region Fields
 
         private readonly bool _isServer;
         private readonly SteamOptions _steamOptions;
         private readonly SteamSocketManager _steamSocketManager;
         private SteamSocketFactory.SteamEndPointWrapper _endPoint;
 
-        #endregion
+#endregion
 
-        #region Class Specific
+#region Class Specific
 
         public SteamSocket(SteamOptions options, bool isServer)
         {
@@ -330,9 +332,9 @@ namespace Mirage.Sockets.FizzySteam
             _steamSocketManager = new SteamSocketManager(options, isServer);
         }
 
-        #endregion
+#endregion
 
-        #region Implementation of ISocket
+#region Implementation of ISocket
 
         /// <summary>
         /// Starts listens for data on an endpoint
@@ -496,6 +498,7 @@ namespace Mirage.Sockets.FizzySteam
             }
         }
 
-        #endregion
+#endregion
     }
 }
+#endif

--- a/Assets/Mirage/Runtime/Transport/FizzySteamyMirror/SteamSocketManager.cs
+++ b/Assets/Mirage/Runtime/Transport/FizzySteamyMirror/SteamSocketManager.cs
@@ -291,7 +291,9 @@ namespace Mirage.Sockets.FizzySteam
             _onConnectionChange = null;
             SteamNetworkingSockets.DestroyPollGroup(_pollGroup);
             _steamInitialized = false;
-            SteamAPI.Shutdown();
+            
+            if(options.InitSteam)
+                SteamAPI.Shutdown();
         }
 
         #endregion


### PR DESCRIPTION
This places all new working code for udp. I had messed up not passing in the address correctly under createCopy for received method so always reverted to 0 address. I implemented a new warning in log so that end user's get warning if user is not in dictionary versus it erroring out.

This implements new able to disable internal initialization of steam to allow end user's to provide there own way. Not tested if nothing provided if any error's spew. I also allowed to change steam options at run time as I never thought of it before.